### PR TITLE
[Fix] /install/ 트레일링 슬래시를 /install로 301 정규화

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,11 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    if (url.pathname === '/install' || url.pathname === '/install/') {
+    if (url.pathname === '/install/') {
+      return Response.redirect(`${url.origin}/install${url.search}`, 301);
+    }
+
+    if (url.pathname === '/install') {
       return handleInstall(request, env);
     }
 


### PR DESCRIPTION
## Summary
- `/install/`을 `/install`로 301 redirect, canonical URL 단일화
- 기존엔 두 경로 모두 동일 컨텐츠를 직접 응답해서 캐시 키·analytics path가 분리되던 문제 해소

## Test plan
- [x] `/install/` 접근 시 `/install`로 301 응답 + 쿼리스트링 보존 확인
- [x] `/install` 정상 응답 확인
- [x] QR(`/install` 캐노니컬) 모바일 스캔 후 스토어 리다이렉트 정상 동작 확인