### PR TITLE
[Fix] analytics.js의 gtag config에 utm 명시적 전달

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,21 @@ function generateAnalyticsJs(env: Env): Response {
   window.gtag = function () { dataLayer.push(arguments); };
   gtag('js', new Date());
 
-  var cid = new URLSearchParams(window.location.search).get('_cid');
-  gtag('config', '${env.GA_ID}', cid ? { client_id: cid } : {});
+  var params = new URLSearchParams(window.location.search);
+  var cid = params.get('_cid');
+  var src = params.get('utm_source');
+  var med = params.get('utm_medium');
+  var cnt = params.get('utm_content');
+  var cmp = params.get('utm_campaign');
+  var trm = params.get('utm_term');
+  var config = {};
+  if (cid) config.client_id = cid;
+  if (src) config.campaign_source = src;
+  if (med) config.campaign_medium = med;
+  if (cnt) config.campaign_content = cnt;
+  if (cmp) config.campaign_name = cmp;
+  if (trm) config.campaign_term = trm;
+  gtag('config', '${env.GA_ID}', config);
 
   window.akifyGetClientId = function (callback) {
     gtag('get', '${env.GA_ID}', 'client_id', callback);


### PR DESCRIPTION
## Summary
- `gtag('config', ...)`가 `client_id`만 명시하고 utm은 GA4 자동 처리에 맡기던 구조 → URL의 utm을 명시적으로 config에 함께 전달
- 증상: cross-domain `_gl` 부재 + `client_id` 명시 조합에서 GA4가 URL utm 자동 읽기를 skip하고 traffic source를 direct/none으로 fallback. `/install` 페이지뷰가 항상 direct로 잡히던 문제
- 수정 후: utm_source / utm_medium / utm_content / utm_campaign / utm_term을 URL에서 읽어 `campaign_*` 필드로 gtag config에 명시 전달 → 그 hit의 traffic source 강제

## Test plan
- [ ] `https://go.akify.io/install?utm_source=test&utm_medium=test_med` 진입 후 GA4 DebugView에서 page_view event의 source/medium 확인
- [ ] cross-domain (akify.io에서 다운로드 클릭 → /install) 도착 hit의 source/medium 확인
- [ ] utm 없이 `/install` 직접 진입 시 fallback 동작 확인 (config 빈 객체 → 기본 attribution)