### PR TITLE
[Fix] redirect 전 GA 비콘 발사 보장하여 UTM 유실 방지

### DIFF
--- a/public/install/index.html
+++ b/public/install/index.html
@@ -112,11 +112,15 @@
         if (isMobile) {
           document.body.classList.add('no-qr');
           var storeUrl = isIOS ? iosBtn.href : androidBtn.href;
-          requestAnimationFrame(function () {
+          if (typeof window.akifyTrackedRedirect === 'function') {
+            window.akifyTrackedRedirect(storeUrl);
+          } else {
             requestAnimationFrame(function () {
-              window.location.replace(storeUrl);
+              requestAnimationFrame(function () {
+                window.location.replace(storeUrl);
+              });
             });
-          });
+          }
           return;
         }
 

--- a/public/merchandise/index.html
+++ b/public/merchandise/index.html
@@ -107,7 +107,11 @@
         attachButtonHandlers(isIOS, isAndroid, postId, webFallback);
 
         if (!isMobile) {
-          window.location.replace(webFallback);
+          if (typeof window.akifyTrackedRedirect === 'function') {
+            window.akifyTrackedRedirect(webFallback);
+          } else {
+            window.location.replace(webFallback);
+          }
           return;
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ function generateAnalyticsJs(env: Env): Response {
   var cnt = params.get('utm_content');
   var cmp = params.get('utm_campaign');
   var trm = params.get('utm_term');
-  var config = {};
+  var config = { transport_type: 'beacon' };
   if (cid) config.client_id = cid;
   if (src) config.campaign_source = src;
   if (med) config.campaign_medium = med;
@@ -173,6 +173,25 @@ function generateAnalyticsJs(env: Env): Response {
 
   window.akifyGetClientId = function (callback) {
     gtag('get', '${env.GA_ID}', 'client_id', callback);
+  };
+
+  window.akifyTrackedRedirect = function (url, opts) {
+    var timeout = (opts && opts.timeout) || 1500;
+    var done = false;
+    var go = function () {
+      if (done) return;
+      done = true;
+      window.location.replace(url);
+    };
+    setTimeout(go, timeout);
+    try {
+      gtag('event', 'redirect', {
+        transport_type: 'beacon',
+        event_callback: go,
+      });
+    } catch (e) {
+      go();
+    }
   };
 })();`);
   }


### PR DESCRIPTION
## 배경
GA 에서 트래픽이 거의 `(direct)/(none)` 으로만 잡히는 현상.

`/install` 모바일 / `/merchandise` 데스크톱 진입 시 `requestAnimationFrame` 두 프레임 만에 (~32ms) `window.location.replace` 로 빠져나가는데, `analytics.js` 내부의 `gtag/js` 라이브러리는 `async` 로 비동기 로드라 그 사이에 도착 못 함. 결과적으로 `gtag('config', ...)` 가 dataLayer 큐에만 쌓이고 실제 collect 비콘은 발사되기 전에 페이지 이탈 → UTM 포함 page_view 가 GA 에 안 잡힘.

## 변경
1. `analytics.js` 의 gtag config 에 `transport_type: 'beacon'` 추가 → 모든 이벤트가 `sendBeacon` 으로 발사되어 페이지 unload 도 살아남음.
2. `window.akifyTrackedRedirect(url, opts?)` 헬퍼 노출 — `event_callback` 으로 비콘 발사 완료 시점을 기다린 뒤 redirect, 1500ms 하드 타임아웃 안전망.
3. `/install` 모바일 redirect, `/merchandise` 데스크톱 redirect 자리를 헬퍼로 교체. 헬퍼 미존재 시 기존 동작으로 fallback.

`/merchandise` 모바일 deep link (`akify://`, `intent://`) 진입은 원래 탭이 살아있어 비콘이 정상 발사되므로 손대지 않음.

## 확인
- `tsc --noEmit` 통과
- 배포 후 `?utm_source=test&utm_medium=qr` 로 모바일/데스크톱 진입하여 GA 실시간 보고서에서 트래픽 소스가 `test/qr` 로 잡히는지 확인 필요