### PR TITLE
[Feat] 매물 deep link에 UTM 파라미터 부착

### DIFF
--- a/public/merchandise/index.html
+++ b/public/merchandise/index.html
@@ -76,15 +76,16 @@
         const storeBtn = document.getElementById("store-btn");
 
         openAppBtn.onclick = () => {
+          const search = window.location.search;
           if (isIOS) {
-            window.location.href = `akify://merchandise/${postId || ''}`;
+            window.location.href = `akify://merchandise/${postId || ''}${search}`;
             setTimeout(() => {
               if (!document.hidden) {
                 window.location.replace(webFallback);
               }
             }, IOS_SCHEME_TIMEOUT_MS);
           } else if (isAndroid) {
-            const intentUrl = `intent://merchandise/${postId || ''}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
+            const intentUrl = `intent://merchandise/${postId || ''}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
             window.location.href = intentUrl;
           }
         };
@@ -118,17 +119,18 @@
         document.body.classList.add('fallback-revealed');
 
         if (postId) {
+          const search = window.location.search;
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
               if (isIOS) {
-                window.location.href = `akify://merchandise/${postId}`;
+                window.location.href = `akify://merchandise/${postId}${search}`;
                 setTimeout(() => {
                   if (!document.hidden) {
                     window.location.replace(webFallback);
                   }
                 }, IOS_SCHEME_TIMEOUT_MS);
               } else if (isAndroid) {
-                const intentUrl = `intent://merchandise/${postId}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
+                const intentUrl = `intent://merchandise/${postId}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
                 window.location.href = intentUrl;
               }
             });


### PR DESCRIPTION
## 배경
`/merchandise/{id}` 페이지의 iOS scheme (`akify://merchandise/{id}`)과 Android intent path에 utm 파라미터가 누락돼 있었음. 광고/공유 링크로 들어와 deep link로 앱 진입 시 앱이 utm을 받지 못해 GA4 어트리뷰션 끊김.

## 변경
`public/merchandise/index.html` 4곳에 `${window.location.search}` 부착:
- L80, L88: 버튼 클릭 시 iOS scheme + Android intent
- L125, L132: 자동 launch 시 iOS scheme + Android intent

## 함께 필요한 변경
AKIFY_APP의 deep link 핸들러에서 utm 추출 후 GA4 `campaign_details` 이벤트로 전송 — 별도 PR로 진행 중.

## 비고
- `/install` 페이지는 이미 utm forwarding 잘 돼 있어서 변경 없음
- 웹 fallback (`web.akify.io/merchandise/{id}?...`)도 이미 작동 중