### PR TITLE
[Fix] 매물 브릿지 web→app 루프 + 스토어 버튼 수정

### DIFF
--- a/public/merchandise/index.html
+++ b/public/merchandise/index.html
@@ -50,7 +50,13 @@
 
     <script>
       const WEB_BASE = "https://web.akify.io";
+      const IOS_STORE = "https://apps.apple.com/kr/app/%EC%95%84%ED%82%A4%ED%8C%8C%EC%9D%B4/id6751454780";
+      const ANDROID_STORE = "https://play.google.com/store/apps/details?id=com.jammering.akify";
       const IOS_SCHEME_TIMEOUT_MS = 1500;
+
+      function isFromWeb() {
+        return document.referrer.includes('web.akify.io/merchandise/');
+      }
 
       function parsePostId() {
         const match = window.location.pathname.match(/^\/merchandise\/([^/?#]+)/);
@@ -71,7 +77,7 @@
         return { isAndroid, isIOS, isMobile };
       }
 
-      function attachButtonHandlers(isIOS, isAndroid, postId, webFallback) {
+      function attachButtonHandlers(isIOS, isAndroid, postId, launchFallback, storeUrl) {
         const openAppBtn = document.getElementById("open-app-btn");
         const storeBtn = document.getElementById("store-btn");
 
@@ -81,17 +87,17 @@
             window.location.href = `akify://merchandise/${postId || ''}${search}`;
             setTimeout(() => {
               if (!document.hidden) {
-                window.location.replace(webFallback);
+                window.location.replace(launchFallback);
               }
             }, IOS_SCHEME_TIMEOUT_MS);
           } else if (isAndroid) {
-            const intentUrl = `intent://merchandise/${postId || ''}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
+            const intentUrl = `intent://merchandise/${postId || ''}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(launchFallback)};end`;
             window.location.href = intentUrl;
           }
         };
 
         storeBtn.onclick = () => {
-          window.location.href = webFallback;
+          window.location.href = storeUrl;
         };
       }
 
@@ -99,13 +105,16 @@
         const { isAndroid, isIOS, isMobile } = detectEnv();
         const postId = parsePostId();
         const webFallback = buildWebFallback(postId);
+        const cameFromWeb = isFromWeb();
+        const storeUrl = isIOS ? IOS_STORE : ANDROID_STORE;
+        const launchFallback = cameFromWeb ? storeUrl : webFallback;
 
         const idValue = document.getElementById("post-id");
         if (postId && idValue) {
           idValue.textContent = postId;
         }
 
-        attachButtonHandlers(isIOS, isAndroid, postId, webFallback);
+        attachButtonHandlers(isIOS, isAndroid, postId, launchFallback, storeUrl);
 
         if (!isMobile) {
           if (typeof window.akifyTrackedRedirect === 'function') {
@@ -118,7 +127,7 @@
 
         document.body.classList.add('fallback-revealed');
 
-        if (postId) {
+        if (postId && !cameFromWeb) {
           const search = window.location.search;
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
@@ -126,11 +135,11 @@
                 window.location.href = `akify://merchandise/${postId}${search}`;
                 setTimeout(() => {
                   if (!document.hidden) {
-                    window.location.replace(webFallback);
+                    window.location.replace(launchFallback);
                   }
                 }, IOS_SCHEME_TIMEOUT_MS);
               } else if (isAndroid) {
-                const intentUrl = `intent://merchandise/${postId}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(webFallback)};end`;
+                const intentUrl = `intent://merchandise/${postId}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(launchFallback)};end`;
                 window.location.href = intentUrl;
               }
             });


### PR DESCRIPTION
## 배경

두 가지 문제가 있었음:

### 1. web → bridge → web 무한 루프

`web.akify.io/merchandise/{id}`에서 "앱에서 보기" 클릭 → `go.akify.io/merchandise/{id}` 진입 → 자동으로 `akify://...` scheme 시도 → 앱 미설치 사용자는 1.5s 타임아웃 후 webFallback(`web.akify.io/merchandise/{id}`)으로 redirect → **시작점으로 돌아옴** → 무한 루프.

### 2. "앱 설치하고 매물 보기" 버튼 동작

라벨/아이콘은 스토어 진입을 의미하는데 실제로는 webFallback(=웹 매물 페이지)로 이동. 의미 불일치.

## 변경

1. **`isFromWeb()` referrer 감지 헬퍼 추가** — `document.referrer`가 `web.akify.io/merchandise/`인지 확인
2. **`IOS_STORE`, `ANDROID_STORE` 상수 추가**
3. **`init()`에서 `launchFallback` 결정**:
   - web에서 옴: `launchFallback = storeUrl` (스토어로 강제)
   - 그 외: `launchFallback = webFallback` (기존 동작 보존, 공유 링크 UX 유지)
4. **자동 launch 조건에 `&& !cameFromWeb` 추가** — web 진입 시 자동 시도 자체를 스킵 (사용자가 버튼으로 명시 선택)
5. **`storeBtn` → 항상 스토어로** (라벨과 동작 일치)

## 동작 매트릭스

| 진입 경로 | 자동 launch | "앱에서 보기" 실패 시 fallback | "앱 설치하고 매물 보기" |
|---|---|---|---|
| web에서 옴 | ❌ 안 함 (루프 회피) | 스토어로 | 스토어로 |
| 직접/공유 링크 | ✅ 시도 (기존) | webFallback (기존) | 스토어로 |
| 데스크톱 | (즉시 webFallback) | n/a | n/a |

## 비고

- referrer가 strip되는 케이스(일부 in-app 브라우저 등)에선 감지 실패 → 기존 동작(web fallback)으로 fallback이라 regression 없음
- AKIFY_WEB 변경 없이 브릿지에서만 해결