### PR TITLE
[Fix] 브릿지 디자인 — 레이아웃 overflow 제거 + 그라디언트 ellipse

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -102,11 +102,17 @@ body.fallback-revealed .loader-page {
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  overflow: hidden;
 }
 
 body.fallback-revealed .index {
   display: flex;
+}
+
+@media (max-height: 720px) {
+  .index {
+    justify-content: flex-start;
+    gap: 32px;
+  }
 }
 
 .leading-section {
@@ -187,14 +193,14 @@ body.fallback-revealed .index {
 }
 
 .btn-primary {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
+  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
   box-shadow: inset 2px 2px 4px 0 var(--color-alpha-white-10);
   outline: 1px solid var(--color-alpha-white-20);
   outline-offset: -1px;
 }
 
 .btn-secondary {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
+  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
   outline: 1px solid var(--color-alpha-white-10);
   outline-offset: -1px;
 }
@@ -269,7 +275,7 @@ body.fallback-revealed .index {
 }
 
 .btn-primary .chip {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.8) 0%, var(--color-neutral-white) 100%);
+  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.8) 0%, var(--color-neutral-white) 100%);
 }
 
 .btn-primary .chip svg {
@@ -277,7 +283,7 @@ body.fallback-revealed .index {
 }
 
 .btn-secondary .chip {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
+  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0) 0%, var(--color-alpha-white-10) 100%);
   outline: 1px solid var(--color-alpha-white-10);
   outline-offset: -1px;
   color: var(--color-neutral-400);


### PR DESCRIPTION
## 변경

### 1. `.index` 레이아웃 overflow 정리
- `overflow: hidden` 제거 — 콘텐츠가 viewport보다 길 때 잘리거나 겹치는 현상 방지 (모바일 작은 화면에서 스토어 버튼/푸터 겹침 이슈)
- `@media (max-height: 720px)` 추가: 짧은 화면에서 `space-between` 대신 `flex-start + gap: 32px` — 콘텐츠 자연 정렬

### 2. radial-gradient: circle → ellipse (4곳)
디자인 의도가 ellipse였는데 `circle` 키워드라 동그란 형태로 그려지던 문제. 다음 4 selector:
- `.btn-primary`
- `.btn-secondary`
- `.btn-primary .chip`
- `.btn-secondary .chip`

## 영향
- install 페이지: 모바일 작은 화면에서 QR/버튼/footer 겹침 해소
- 매물 페이지: 동일 클래스 사용 → 같은 효과
- 데스크톱 큰 화면: media query 미적용으로 기존 `space-between` 유지