### PR TITLE
[Fix] 매물 브릿지 fallback 강화 + install 카피 변경

### DIFF
--- a/public/install/index.html
+++ b/public/install/index.html
@@ -183,7 +183,7 @@
         </div>
 
         <div class="title-group">
-          <div class="title">AKIFY 앱 설치하기</div>
+          <div class="title">아키파이 앱 설치하기</div>
           <div class="description">휴대폰 카메라로 QR을 스캔하세요</div>
         </div>
 
@@ -193,7 +193,7 @@
           <a class="btn btn-secondary" id="ios-btn" href="#">
             <svg class="icon-left"><use href="/assets/icons.svg#apple" /></svg>
             <div class="text-group">
-              <span class="label">Apple</span>
+              <span class="label">Download on the</span>
               <span class="action">App Store</span>
             </div>
             <div class="chip">
@@ -204,7 +204,7 @@
           <a class="btn btn-secondary" id="android-btn" href="#">
             <svg class="icon-left"><use href="/assets/icons.svg#google-play" /></svg>
             <div class="text-group">
-              <span class="label">Google</span>
+              <span class="label">Get it on</span>
               <span class="action">Play Store</span>
             </div>
             <div class="chip">
@@ -215,7 +215,7 @@
       </div>
 
       <div class="footer">
-        <a id="browse-btn" href="https://akify.io" class="browse-link">AKIFY 둘러보기 →</a>
+        <a id="browse-btn" href="https://akify.io" class="browse-link">더 알아보기 →</a>
         <div class="copyright">2026 Jammering™ All Rights reserved.</div>
         <a href="mailto:info@jammering.com" class="contact">문의: info@jammering.com</a>
       </div>

--- a/public/merchandise/index.html
+++ b/public/merchandise/index.html
@@ -54,8 +54,21 @@
       const ANDROID_STORE = "https://play.google.com/store/apps/details?id=com.jammering.akify";
       const IOS_SCHEME_TIMEOUT_MS = 1500;
 
-      function isFromWeb() {
-        return document.referrer.includes('web.akify.io/merchandise/');
+      function shouldSkipWebFallback() {
+        if (document.referrer.includes('web.akify.io/merchandise/')) return true;
+        if (document.referrer.includes('go.akify.io')) return true;
+        if (new URLSearchParams(window.location.search).get('intent') === 'open_app') return true;
+        return false;
+      }
+
+      function launchIosScheme(scheme, fallback) {
+        const start = Date.now();
+        window.location.href = scheme;
+        setTimeout(() => {
+          if (Date.now() - start < IOS_SCHEME_TIMEOUT_MS + 200 && !document.hidden) {
+            window.location.replace(fallback);
+          }
+        }, IOS_SCHEME_TIMEOUT_MS);
       }
 
       function parsePostId() {
@@ -84,12 +97,7 @@
         openAppBtn.onclick = () => {
           const search = window.location.search;
           if (isIOS) {
-            window.location.href = `akify://merchandise/${postId || ''}${search}`;
-            setTimeout(() => {
-              if (!document.hidden) {
-                window.location.replace(launchFallback);
-              }
-            }, IOS_SCHEME_TIMEOUT_MS);
+            launchIosScheme(`akify://merchandise/${postId || ''}${search}`, launchFallback);
           } else if (isAndroid) {
             const intentUrl = `intent://merchandise/${postId || ''}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(launchFallback)};end`;
             window.location.href = intentUrl;
@@ -105,9 +113,9 @@
         const { isAndroid, isIOS, isMobile } = detectEnv();
         const postId = parsePostId();
         const webFallback = buildWebFallback(postId);
-        const cameFromWeb = isFromWeb();
+        const useStoreFallback = shouldSkipWebFallback();
         const storeUrl = isIOS ? IOS_STORE : ANDROID_STORE;
-        const launchFallback = cameFromWeb ? storeUrl : webFallback;
+        const launchFallback = useStoreFallback ? storeUrl : webFallback;
 
         const idValue = document.getElementById("post-id");
         if (postId && idValue) {
@@ -127,17 +135,12 @@
 
         document.body.classList.add('fallback-revealed');
 
-        if (postId && !cameFromWeb) {
+        if (postId) {
           const search = window.location.search;
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
               if (isIOS) {
-                window.location.href = `akify://merchandise/${postId}${search}`;
-                setTimeout(() => {
-                  if (!document.hidden) {
-                    window.location.replace(launchFallback);
-                  }
-                }, IOS_SCHEME_TIMEOUT_MS);
+                launchIosScheme(`akify://merchandise/${postId}${search}`, launchFallback);
               } else if (isAndroid) {
                 const intentUrl = `intent://merchandise/${postId}${search}#Intent;scheme=akify;package=com.jammering.akify;S.browser_fallback_url=${encodeURIComponent(launchFallback)};end`;
                 window.location.href = intentUrl;


### PR DESCRIPTION
2개 commit으로 분리.

## 1. fix: 매물 브릿지 fallback 감지 강화 + 자동 launch 항상 시도

### 변경
- **`isFromWeb()` → `shouldSkipWebFallback()`** — referrer 매치 범위 확장:
  - `web.akify.io/merchandise/...` (기존)
  - `go.akify.io` 자기 자신 (self-referral, defensive)
  - URL 파라미터 `?intent=open_app` (forward-compatible — AKIFY_WEB이 추후 추가 가능)
- **자동 launch 조건에서 `&& !cameFromWeb` 제거** — cameFromWeb=true여도 scheme 시도해야 앱 설치자가 자동으로 앱 진입 가능. 이전 PR(#29)의 over-protection이었음.
- **`launchIosScheme(scheme, fallback)` 헬퍼 추가** — fallback 안정화:
  - 기존: `setTimeout(() => { if (!document.hidden) replace })` — 다이얼로그 동안 hidden=true 잡혀서 fallback 안 뛰는 케이스 발생
  - 신규: `Date.now() - start < TIMEOUT + 200 && !document.hidden` — 타이머가 정상 시각에 깨면(=백그라운드 안 됨 = 앱 안 열림) fallback 발동

### 동작 매트릭스 (4 케이스 모두 정상)
| 진입 | 앱 설치자 | 미설치자 |
|---|---|---|
| 직접 진입 (cameFromWeb=false) | 자동 launch → 앱 열림 | fallback → web (콘텐츠 보기) |
| web에서 옴 (cameFromWeb=true) | 자동 launch → 앱 열림 | fallback → store (루프 회피) |

## 2. chore: install 페이지 카피 변경 (한글화 + 스토어 라벨)

`public/install/index.html` 카피 4곳:
- "AKIFY 앱 설치하기" → "아키파이 앱 설치하기"
- iOS 버튼 "Apple" → "Download on the" (App Store)
- Android 버튼 "Google" → "Get it on" (Play Store)
- "AKIFY 둘러보기 →" → "더 알아보기 →"